### PR TITLE
Updated route URL to match "type" validation

### DIFF
--- a/.github/routes-documentation/sessions/session-post.md
+++ b/.github/routes-documentation/sessions/session-post.md
@@ -4,7 +4,7 @@
 
 * **URL**
 
-  _/sessions/_
+  _/sessions?type=${user|provider}_
 
 * **Method:**
   


### PR DESCRIPTION
I have noticed that when you try to login the controller is waiting for an query string "type" (Of a possible future enumeration, I guess). So I updated this file to have no problems when first trying the API.