### PR TITLE
Updated docker-compose containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Ignore Docker Override Configurations
+docker-compose.override.yml
+docker-compose.override.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,19 @@ services:
     db:
       image: postgres
       environment:
-        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD},
+        POSTGRES_USER: ${POSTGRES_USER}
+        POSTGRES_DB: ${POSTGRES_DATABASE}
       ports:
         - "5432:5432"
+    mongodb:
+      image: mongo:bionic
+      environment:
+        MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
+        MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
+        MONGO_INITDB_DATABASE: ${MONGO_INITDB_DATABASE}
+      ports:
+        - "27017:27017"
 volumes:
   redis-data:
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     db:
       image: postgres
       environment:
-        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD},
+        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
         POSTGRES_USER: ${POSTGRES_USER}
         POSTGRES_DB: ${POSTGRES_DATABASE}
       ports:


### PR DESCRIPTION
I have updated docker-compose (dc) file to use MongoDB with the given .env variables.

Added .env variables for Postgres to do successful migration with sequelize.

Now Git ignores docker-compose override files. Developers can now setup other containers on the same folder without need to change the original dc file.